### PR TITLE
Work around overflowing SVG text with fractional font sizes.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,9 +228,12 @@ impl<'spir> PetSpirv<'spir> {
     pub fn add_fn_to_dot(&self, write: &mut impl Write) {
         let fn_name = self.module.get_name_fn(&self.function).unwrap_or("Unknown");
         writeln!(write, "digraph {{").unwrap();
-        writeln!(write, "graph [fontname=\"monospace\"];").unwrap();
-        writeln!(write, "node [fontname=\"monospace\"];").unwrap();
-        writeln!(write, "edge [fontname=\"monospace\"];").unwrap();
+        // HACK(eddyb) the `13.5` font size works around a graphviz bug where the
+        // default size of `14` would compute metrics as `13.5` but render as `14`,
+        // resulting in overflowing text for SVG, and generally differ from PNG.
+        writeln!(write, "graph [fontname=\"monospace\", fontsize=13.5];").unwrap();
+        writeln!(write, "node [fontname=\"monospace\", fontsize=13.5];").unwrap();
+        writeln!(write, "edge [fontname=\"monospace\", fontsize=13.5];").unwrap();
         let fn_id = self.function.def.as_ref().unwrap().result_id.unwrap();
         let entry = self.function.blocks[0]
             .label


### PR DESCRIPTION
If you've had text overflow out of boxes it's supposed to be in, in SVG output, this should fix it (assuming "monospace" means the same thing between `dot` and the browser you're viewing the SVG on, that's its own can of worms).

I'm not sure what happens exactly, but I suspect something in graphviz rounds incorrectly.
According to https://gitlab.com/graphviz/graphviz/-/issues/107#note_438706659, this *may* be fixed in latest (unreleased?) graphviz, but I haven't tried building that to confirm.

Either way, whenever it's fixed upstream, this hack shouldn't break anything, it's just a font size.